### PR TITLE
Add custom color variables to CSS root

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,3 +12,10 @@ body {
   display: flex;
   flex-direction: column;
 }
+:root {
+  --timberwolf: #DAD7CD; /* Light grayish yellow */
+  --sage: #A3B18A; /* Muted green */
+  --fern-green: #588157; /* Deep green */
+  --hunter-green: #3A5A40; /* Dark green */
+  --brunswick-green: #344E41; /* Very dark green */
+}


### PR DESCRIPTION
Defined five new CSS custom properties for color theming, including timberwolf, sage, fern-green, hunter-green, and brunswick-green. Closes issue #16 