### PR TITLE
Issue #92 - Rename ProduceList page to ViewPantry and update navbar

### DIFF
--- a/src/app/view-pantry/page.tsx
+++ b/src/app/view-pantry/page.tsx
@@ -8,7 +8,7 @@ import ProduceListWithGrouping from '@/components/SearchBar'; // client componen
 
 type SessionUser = { id: string; email: string; randomKey: string };
 
-const ProduceListPage = async () => {
+const ViewPantryPage = async () => {
   const session = (await getServerSession(authOptions)) as { user: SessionUser } | null;
   loggedInProtectedPage(session);
 
@@ -33,4 +33,4 @@ const ProduceListPage = async () => {
   );
 };
 
-export default ProduceListPage;
+export default ViewPantryPage;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -26,7 +26,7 @@ const NavBar: React.FC = () => {
                 <Nav.Link id="list-stuff-nav" href="/list" key="list" active={pathName === '/list'}>
                   List Stuff
                 </Nav.Link>,
-                <Nav.Link id="view-pantry-nav" href="/view" key="view" active={pathName === '/view-pantry'}>
+                <Nav.Link id="view-pantry-nav" href="/view-pantry" key="view" active={pathName === '/view-pantry'}>
                   View Pantry
                 </Nav.Link>,
               ]


### PR DESCRIPTION
Renamed the ProduceList page to ViewPantry for clarity and updated the Navbar link to point to /view-pantry, ensuring correct navigation and active state. Closes issue #92 