### PR TITLE
Issue #111 - Update CI workflow name to pantry-pals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci-nextjs-application-template
+name: pantry-pals
 
 on:
   push:


### PR DESCRIPTION
Renamed the GitHub Actions workflow from 'ci-nextjs-application-template' to 'pantry-pals' to reflect the current project name.