### PR TITLE
Change Produce.quantity from Decimal to Float

### DIFF
--- a/prisma/migrations/20250925042911_quantity_to_float/migration.sql
+++ b/prisma/migrations/20250925042911_quantity_to_float/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `quantity` on the `Produce` table. The data in that column could be lost. The data in that column will be cast from `Decimal(10,2)` to `DoublePrecision`.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Produce" ALTER COLUMN "quantity" SET DATA TYPE DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,7 +71,7 @@ model Produce {
   name              String
   type              String
   location          String
-  quantity          Decimal            @db.Decimal(10, 2)
+  quantity          Float
   unit              String
   expiration        DateTime?
   owner             String


### PR DESCRIPTION
Updated the Produce model's quantity field from Decimal to Float in the Prisma schema and corresponding migration. This change may affect existing data due to type casting from Decimal(10,2) to Double Precision.