### PR TITLE
Add edit modal to ProduceCard component

### DIFF
--- a/src/components/ProduceCard.tsx
+++ b/src/components/ProduceCard.tsx
@@ -3,6 +3,8 @@
 import { Card, ListGroup, Image, Button } from 'react-bootstrap/';
 import Link from 'next/link';
 import type { Produce } from '@prisma/client';
+import { useState } from 'react';
+import EditProduceModal from './EditProduceModal';
 
 type Props = { produce: Produce };
 
@@ -15,6 +17,7 @@ const formatDate = (d?: Date | string | null) => {
 
 export default function ProduceCard({ produce }: Props) {
   const imageSrc = produce.image || '/no-image.png'; // default image if none provided
+  const [showModal, setShowModal] = useState(false);
 
   return (
     <Card className="h-100 mb-3 image-shadow">
@@ -55,7 +58,7 @@ export default function ProduceCard({ produce }: Props) {
           </ListGroup.Item>
         </ListGroup>
         <Card.Footer className="d-flex">
-          <Button className="me-2 editbutton" href={`/edit/${produce.id}`}>
+          <Button className="me-2 editbutton" onClick={() => setShowModal(true)}>
             Edit
           </Button>
           <Button variant="danger" className="deletebutton" href={`/delete/${produce.id}`}>
@@ -63,6 +66,13 @@ export default function ProduceCard({ produce }: Props) {
           </Button>
         </Card.Footer>
       </Card.Body>
+
+      {/* Modal component for editing produce item */}
+      <EditProduceModal
+        show={showModal}
+        onHide={() => setShowModal(false)}
+        produce={produce}
+      />
     </Card>
   );
 }


### PR DESCRIPTION
Replaces the edit button's link with a modal trigger and integrates the EditProduceModal component. This allows editing produce items directly within a modal dialog for improved user experience. #162 