### PR TITLE
Update test to check Add Produce modal functionality

### DIFF
--- a/tests/acceptance/add.testcafe.js
+++ b/tests/acceptance/add.testcafe.js
@@ -20,7 +20,7 @@ test('Add Produce modal opens and form loads', async t => {
     await t.navigateTo('https://pantry-pal-gamma.vercel.app/view-pantry');
 
     // Click the "Add Item" button to open the modal
-    const addButton = Selector('tbody tr').nth(0).find('button.btn-add');
+    const addButton = Selector('button.btn-add');
     await t.click(addButton);
 
     // Check that the modal appeared and has a form

--- a/tests/acceptance/add.testcafe.js
+++ b/tests/acceptance/add.testcafe.js
@@ -1,29 +1,39 @@
 import { Selector } from 'testcafe';
 
-fixture('Add Page')
+fixture('Add Produce Modal')
     .page('https://pantry-pal-gamma.vercel.app/auth/signin');
 
 const testEmail = 'admin@foo.com';
 const testPassword = 'changeme';
 
-test('Add page loads', async t => {
+test('Add Produce modal opens and form loads', async t => {
     // Sign in
     await t
         .typeText('input[name="email"]', testEmail, { replace: true })
         .typeText('input[name="password"]', testPassword, { replace: true })
         .click('button[type="submit"]');
 
-    // Wait for redirect to /list (or home after signin)
+    // Wait for redirect after signin
     await t.expect(t.eval(() => window.location.pathname)).notEql('/auth/signin', { timeout: 10000 });
 
-    // Go to /add page
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/add');
+    // Navigate to produce list page
+    await t.navigateTo('https://pantry-pal-gamma.vercel.app/view-pantry');
 
-    // Check that the AddStuffForm rendered
-    const addForm = Selector('form'); // assuming AddStuffForm renders a <form>
-    await t.expect(addForm.exists).ok('Expected AddStuffForm to be present');
+    // Click the "Add Item" button to open the modal
+    const addButton = Selector('tbody tr').nth(0).find('button.btn-add');
+    await t.click(addButton);
 
-    // Optional: check a field in the form if you want
-    const nameInput = Selector('input[name="name"]'); // replace with actual input name
+    // Check that the modal appeared and has a form
+    const addModal = Selector('.modal-dialog');
+    await t.expect(addModal.exists).ok('Expected AddProduceModal to appear');
+
+    const addForm = addModal.find('form');
+    await t.expect(addForm.exists).ok('Expected form inside modal');
+
+    // Optional: check specific fields
+    const nameInput = addForm.find('input[name="name"]');
     await t.expect(nameInput.exists).ok('Expected "name" input to exist');
+
+    const unitSelect = addForm.find('select');
+    await t.expect(unitSelect.exists).ok('Expected "unit" dropdown to exist');
 });


### PR DESCRIPTION
The acceptance test now verifies that the Add Produce modal opens from the produce list page and that its form and fields are rendered correctly. This replaces the previous test for the /add page and adapts to the new modal-based workflow.