### PR TITLE
Remove 'Add Stuff' link from Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,9 +25,6 @@ const NavBar: React.FC = () => {
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
           <Navbar.Collapse id="basic-navbar-nav">
             <Nav className="me-auto justify-content-start">
-              <Nav.Link as={Link} id="add-stuff-nav" href="/add" active={isActive('/add')}>
-                Add Stuff
-              </Nav.Link>
               <Nav.Link as={Link} id="view-pantry-nav" href="/view-pantry" active={isActive('/view-pantry')}>
                 View Pantry
               </Nav.Link>


### PR DESCRIPTION
The 'Add Stuff' navigation link has been removed from the Navbar component. This streamlines the navigation and may reflect a change in available features or user flow.