### PR TITLE
Create Migration - Add Recipe table and restockThreshold to Produce

### DIFF
--- a/prisma/migrations/20251008105000_add_recipes/migration.sql
+++ b/prisma/migrations/20251008105000_add_recipes/migration.sql
@@ -1,0 +1,27 @@
+-- AlterTable
+ALTER TABLE "public"."Produce" ADD COLUMN     "restockThreshold" DOUBLE PRECISION;
+
+-- CreateTable
+CREATE TABLE "public"."Recipe" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "imageUrl" TEXT,
+    "cuisine" TEXT NOT NULL,
+    "dietary" TEXT[],
+    "ingredients" TEXT[],
+    "owner" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Recipe_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Recipe_title_idx" ON "public"."Recipe"("title");
+
+-- CreateIndex
+CREATE INDEX "Recipe_cuisine_idx" ON "public"."Recipe"("cuisine");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Recipe_title_owner_key" ON "public"."Recipe"("title", "owner");


### PR DESCRIPTION
Introduces a new Recipe table with relevant fields and indexes for title, cuisine, and unique title-owner pairs. Also adds a restockThreshold column to the Produce table to support inventory management.