### PR TITLE
Switch test URLs to localhost and add table column

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -30,6 +30,7 @@ function FlatTable({ rows }: { rows: Produce[] }) {
           <th>Type</th>
           <th>Location</th>
           <th>Quantity</th>
+          <th>Restock Threshold</th>
           <th>Expiration</th>
           <th>Edit</th>
         </tr>

--- a/tests/acceptance/aboutus.testcafe.js
+++ b/tests/acceptance/aboutus.testcafe.js
@@ -1,7 +1,7 @@
 import { Selector, t } from 'testcafe';
 
 fixture('About Us Page')
-    .page('https://pantry-pal-gamma.vercel.app/aboutus');
+    .page('http://localhost:3000/aboutus');
 
 test('About Us page loads', async t => {
     // Check for main heading

--- a/tests/acceptance/add.testcafe.js
+++ b/tests/acceptance/add.testcafe.js
@@ -1,7 +1,7 @@
 import { Selector } from 'testcafe';
 
 fixture('Add Produce Modal')
-    .page('https://pantry-pal-gamma.vercel.app/auth/signin');
+    .page('http://localhost:3000/auth/signin');
 
 const testEmail = 'admin@foo.com';
 const testPassword = 'changeme';
@@ -17,7 +17,7 @@ test('Add Produce modal opens and form loads', async t => {
     await t.expect(t.eval(() => window.location.pathname)).notEql('/auth/signin', { timeout: 10000 });
 
     // Navigate to produce list page
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/view-pantry');
+    await t.navigateTo('http://localhost:3000/view-pantry');
 
     // Click the "Add Item" button to open the modal
     const addButton = Selector('button.btn-add');

--- a/tests/acceptance/changepassword.testcafe.js
+++ b/tests/acceptance/changepassword.testcafe.js
@@ -16,7 +16,7 @@ const signIn = async (email, password) => {
 
 // Helper to check that signout page loads
 const signOut = async () => {
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/auth/signout');
+    await t.navigateTo('http://localhost:3000/auth/signout');
 
     // Check for a heading or text that exists on the signout page
     const signOutHeading = Selector('h1').withText(/sign out/i);
@@ -24,12 +24,12 @@ const signOut = async () => {
 };
 
 fixture('Change Password Tests')
-    .page('https://pantry-pal-gamma.vercel.app');
+            .page('http://localhost:3000');
 
 // 1️⃣ Check Change Password page loads
 test('Change password page loads', async t => {
     await signIn(adminEmail, oldPassword);
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/auth/change-password');
+    await t.navigateTo('http://localhost:3000/auth/change-password');
 
     const title = Selector('h1').withText('Change Password');
     await t.expect(title.exists).ok({ timeout: 5000 });

--- a/tests/acceptance/forgotpassword.testcafe.js
+++ b/tests/acceptance/forgotpassword.testcafe.js
@@ -1,7 +1,7 @@
 import { Selector, t } from 'testcafe';
 
 fixture('Forgot Password Page')
-    .page('https://pantry-pal-gamma.vercel.app/auth/forgot-password');
+    .page('http://localhost:3000/auth/forgot-password');
 
 // ✅ Test that the Forgot Password page loads
 test('Forgot Password page loads', async t => {

--- a/tests/acceptance/homepage.testcafe.js
+++ b/tests/acceptance/homepage.testcafe.js
@@ -1,7 +1,7 @@
 import { Selector, t } from 'testcafe';
 
 fixture('Homepage')
-  .page('pantry-pal-gamma.vercel.app');
+  .page('http://localhost:3000/');
 
 test('Homepage loads', async t => {
     // Check that the page title exists and is correct (optional)

--- a/tests/acceptance/list-and-edit.testcafe.js
+++ b/tests/acceptance/list-and-edit.testcafe.js
@@ -2,7 +2,7 @@ import { Selector, t } from 'testcafe';
 
 // --- Helpers ---
 const signIn = async () => {
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/auth/signin');
+    await t.navigateTo('http://localhost:3000/auth/signin');
 
     await t
         .typeText('input[name="email"]', 'admin@foo.com', { replace: true })
@@ -15,11 +15,11 @@ const signIn = async () => {
 
 // --- Tests ---
 fixture('View Pantry & Edit Flow')
-    .page('https://pantry-pal-gamma.vercel.app');
+    .page('http://localhost:3000');
 
 test('View Pantry page loads', async t => {
     await signIn();
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/view-pantry');
+    await t.navigateTo('http://localhost:3000/view-pantry');
 
     const viewPantryContainer = Selector('#view-pantry');
     await t.expect(viewPantryContainer.exists).ok('Expected view pantry container to exist');
@@ -27,7 +27,7 @@ test('View Pantry page loads', async t => {
 
 test('Click edit link works', async t => {
     await signIn();
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/view-pantry');
+    await t.navigateTo('http://localhost:3000/view-pantry');
 
     const firstEditLink = Selector('tbody tr').nth(0).find('button.btn-edit');
     await t.expect(firstEditLink.exists).ok('Expected first edit link to exist');
@@ -40,7 +40,7 @@ test('Click edit link works', async t => {
 
 test('Edit form can modify item', async t => {
     await signIn();
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/view-pantry');
+    await t.navigateTo('http://localhost:3000/view-pantry');
 
     const firstEditLink = Selector('tbody tr').nth(0).find('button.btn-edit');
     await t.click(firstEditLink);

--- a/tests/acceptance/signin.testcafe.js
+++ b/tests/acceptance/signin.testcafe.js
@@ -2,7 +2,7 @@ import SignInPage from './pages/SignInPage';
 import { t } from 'testcafe';
 
 fixture('SignIn Page')
-  .page('https://pantry-pal-gamma.vercel.app/auth/signin');
+  .page('http://localhost:3000/auth/signin');
 
 test('SignUp page loads', async t => {
   await SignInPage.isDisplayed();

--- a/tests/acceptance/signout.testcafe.js
+++ b/tests/acceptance/signout.testcafe.js
@@ -2,7 +2,7 @@ import { Selector, t } from 'testcafe';
 
 // Helper to sign in first
 const signIn = async () => {
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/auth/signin');
+    await t.navigateTo('http://localhost:3000/auth/signin');
 
     await t
         .typeText('input[name="email"]', 'admin@foo.com', { replace: true })
@@ -14,12 +14,12 @@ const signIn = async () => {
 };
 
 fixture('Sign Out')
-    .page('https://pantry-pal-gamma.vercel.app');
+    .page('http://localhost:3000');
 
 // ✅ Test if Sign Out page loads
 test('Sign Out page loads', async t => {
     await signIn();
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/auth/signout');
+    await t.navigateTo('http://localhost:3000/auth/signout');
 
     const signOutTitle = Selector('h1').withText('Sign Out');
     await t.expect(signOutTitle.exists).ok();
@@ -28,7 +28,7 @@ test('Sign Out page loads', async t => {
 // ✅ Test if the Sign Out button works
 test('Sign out button works', async t => {
     await signIn();
-    await t.navigateTo('https://pantry-pal-gamma.vercel.app/auth/signout');
+    await t.navigateTo('http://localhost:3000/auth/signout');
 
     const signOutButton = Selector('[data-testid="signout-button"]');
     await t.click(signOutButton);

--- a/tests/acceptance/signup.testcafe.js
+++ b/tests/acceptance/signup.testcafe.js
@@ -2,7 +2,7 @@ import { Selector, t } from 'testcafe';
 import SignUpPage from './pages/SignUpPage';
 
 fixture('SignUp Page')
-  .page('https://pantry-pal-gamma.vercel.app/auth/signup');
+  .page('http://localhost:3000/auth/signup');
 
 test('Page loads', async t => {
   await SignUpPage.isDisplayed();

--- a/tests/acceptance/viewpantry.testcafe.js
+++ b/tests/acceptance/viewpantry.testcafe.js
@@ -2,7 +2,7 @@ import { Selector, t } from 'testcafe';
 
 const adminEmail = 'admin@foo.com';
 const password = 'changeme';
-const baseUrl = 'https://pantry-pal-gamma.vercel.app';
+const baseUrl = 'http://localhost:3000/';
 
 // ----------
 // HELPERS


### PR DESCRIPTION
Updated all TestCafe acceptance tests to use 'http://localhost:3000' instead of the production URL for local development. Also added a 'Restock Threshold' column to the produce table in SearchBar.tsx.