### PR TITLE
Add restock threshold column to table header

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -30,6 +30,7 @@ function FlatTable({ rows }: { rows: Produce[] }) {
           <th>Type</th>
           <th>Location</th>
           <th>Quantity</th>
+          <th>Restock Threshhold</th>
           <th>Expiration</th>
           <th>Edit</th>
         </tr>


### PR DESCRIPTION
Introduces a new 'Restock Threshhold' column in the FlatTable component to display restock information for produce items.