### PR TITLE
Remove inline margin-top from Hero container

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -15,7 +15,7 @@ export default function Hero() {
 
   return (
     <section className="py-5" style={{ backgroundColor: 'var(--timberwolf)' }}>
-      <div className="container" style={{ marginTop: 75 }}>
+      <div className="container">
         <div className="row align-items-center">
           {/* Left: Logo */}
           <div className="col-md-6 mb-4 mb-md-0 mt-5">


### PR DESCRIPTION
Eliminated the inline style setting marginTop to 75 on the Hero section's container div to rely on default or external spacing. This helps maintain consistent layout and styling.