### PR TITLE
Issue 248

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,9 +86,7 @@ footer a {
   }
 }
 
-label:has(+ input:required)::after,
-label:has(+ select:required)::after,
-label:has(+ textarea:required)::after {
+.required-field::after {
     content: "*";
     color: red;
 }

--- a/src/components/produce/AddProduceModal.tsx
+++ b/src/components/produce/AddProduceModal.tsx
@@ -115,7 +115,7 @@ const AddProduceModal = ({ show, onHide, produce }: AddProduceModalProps) => {
           <Row className="mb-3">
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Name</Form.Label>
+                <Form.Label className="mb-0 required-field">Name</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('name')}
@@ -128,7 +128,7 @@ const AddProduceModal = ({ show, onHide, produce }: AddProduceModalProps) => {
             </Col>
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Type</Form.Label>
+                <Form.Label className="mb-0 required-field">Type</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('type')}
@@ -145,7 +145,7 @@ const AddProduceModal = ({ show, onHide, produce }: AddProduceModalProps) => {
           <Row>
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Location</Form.Label>
+                <Form.Label className="mb-0 required-field">Location</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('location')}
@@ -158,7 +158,7 @@ const AddProduceModal = ({ show, onHide, produce }: AddProduceModalProps) => {
             </Col>
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Storage</Form.Label>
+                <Form.Label className="mb-0 required-field">Storage</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('storage')}
@@ -175,7 +175,7 @@ const AddProduceModal = ({ show, onHide, produce }: AddProduceModalProps) => {
           <Row className="mb-3">
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Quantity</Form.Label>
+                <Form.Label className="mb-0 required-field">Quantity</Form.Label>
                 <Form.Control
                   type="number"
                   {...register('quantity')}
@@ -189,7 +189,7 @@ const AddProduceModal = ({ show, onHide, produce }: AddProduceModalProps) => {
             </Col>
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Unit</Form.Label>
+                <Form.Label className="mb-0 required-field">Unit</Form.Label>
                 <Form.Select
                   defaultValue={unitOptions[0]}
                   required

--- a/src/components/produce/EditProduceModal.tsx
+++ b/src/components/produce/EditProduceModal.tsx
@@ -83,7 +83,7 @@ const EditProduceModal = ({ show, onHide, produce }: EditProduceModalProps) => {
           <Row className="mb-3">
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Name</Form.Label>
+                <Form.Label className="mb-0 required-field">Name</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('name')}
@@ -98,7 +98,7 @@ const EditProduceModal = ({ show, onHide, produce }: EditProduceModalProps) => {
 
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Type</Form.Label>
+                <Form.Label className="mb-0 required-field">Type</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('type')}
@@ -114,7 +114,7 @@ const EditProduceModal = ({ show, onHide, produce }: EditProduceModalProps) => {
           <Row className="mb-3">
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Location</Form.Label>
+                <Form.Label className="mb-0 required-field">Location</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('location')}
@@ -128,7 +128,7 @@ const EditProduceModal = ({ show, onHide, produce }: EditProduceModalProps) => {
             </Col>
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Storage</Form.Label>
+                <Form.Label className="mb-0 required-field">Storage</Form.Label>
                 <Form.Control
                   type="text"
                   {...register('storage')}
@@ -145,7 +145,7 @@ const EditProduceModal = ({ show, onHide, produce }: EditProduceModalProps) => {
           <Row className="mb-3">
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Quantity</Form.Label>
+                <Form.Label className="mb-0 required-field">Quantity</Form.Label>
                 <Form.Control
                   type="number"
                   {...register('quantity')}
@@ -160,7 +160,7 @@ const EditProduceModal = ({ show, onHide, produce }: EditProduceModalProps) => {
             </Col>
             <Col xs={6} className="text-center">
               <Form.Group>
-                <Form.Label className="mb-0">Unit</Form.Label>
+                <Form.Label className="mb-0 required-field">Unit</Form.Label>
                 <Form.Select
                   defaultValue={unitChoice}
                   required


### PR DESCRIPTION
This pull request improves form validation and user experience in the produce modals by visually marking required fields and enforcing input requirements. The main changes are the addition of a red asterisk to required field labels and the use of the `required` attribute for key form inputs in both the Add and Edit produce modals.

**Form validation and UI improvements:**

* Added a `.required-field` CSS class in `globals.css` to append a red asterisk to labels of required fields, making them visually distinct for users.
* Updated all relevant form labels in `AddProduceModal.tsx` and `EditProduceModal.tsx` to use the `.required-field` class for required fields: Name, Type, Location, Storage, Quantity, and Unit. [[1]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL118-R118) [[2]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL131-R135) [[3]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL147-R152) [[4]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL159-R165) [[5]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL175-R182) [[6]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL188-R195) [[7]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cR213) [[8]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L86-R86) [[9]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L101-R105) [[10]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L116-R121) [[11]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L129-R135) [[12]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L145-R152) [[13]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L159-R166) [[14]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8R189)
* Added the `required` HTML attribute to all key input fields in both modals to enforce client-side validation for Type, Location, Storage, Quantity, and Unit fields. [[1]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL131-R135) [[2]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL147-R152) [[3]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL159-R165) [[4]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL175-R182) [[5]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cL188-R195) [[6]](diffhunk://#diff-b8ee49e17f011318cbef27ca3bc95a9e6f7bef35127bb43143ebbd2598b18d7cR213) [[7]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L101-R105) [[8]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L116-R121) [[9]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L129-R135) [[10]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L145-R152) [[11]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8L159-R166) [[12]](diffhunk://#diff-e95e48dcebf600dfed3a7c64bfed5658004101be17144bc2a74f69b0e63dc5b8R189)