### PR TITLE
Issue 352 - Checkboxes in shopping list modal

### DIFF
--- a/src/components/shopping-list/ViewShoppingListModal.tsx
+++ b/src/components/shopping-list/ViewShoppingListModal.tsx
@@ -6,8 +6,8 @@
 
 import { useState, useEffect } from 'react';
 import { Button, Col, Modal, Row, Table } from 'react-bootstrap';
-import AddToShoppingListModal from './AddToShoppingListModal';
 import { BagCheckFill } from 'react-bootstrap-icons';
+import AddToShoppingListModal from './AddToShoppingListModal';
 
 interface ShoppingListItem {
   id: number;
@@ -35,11 +35,14 @@ const ViewShoppingListModal = ({ show, onHide, shoppingList }: ViewShoppingListM
   const [items, setItems] = useState<ShoppingListItem[]>([]);
   const [showAddModal, setShowAddModal] = useState(false);
   const [deletingItemId, setDeletingItemId] = useState<number | null>(null);
+  const [checkedState, setCheckedState] = useState<Record<number, boolean>>({});
 
   // Update items when the shopping list changes
   useEffect(() => {
     if (shoppingList?.items) {
       setItems(shoppingList.items);
+      const saved = localStorage.getItem(`checkboxes-${shoppingList.id}`);
+      if (saved) setCheckedState(JSON.parse(saved));
     }
   }, [shoppingList]);
 
@@ -79,6 +82,18 @@ const ViewShoppingListModal = ({ show, onHide, shoppingList }: ViewShoppingListM
     }
   };
 
+  const toggleCheckbox = (itemId: number) => {
+    setCheckedState(prev => {
+      const updated = { ...prev, [itemId]: !prev[itemId] };
+
+      if (shoppingList) {
+        localStorage.setItem(`checkboxes-${shoppingList.id}`, JSON.stringify(updated));
+      }
+
+      return updated;
+    });
+  };
+
   if (!shoppingList) return null;
 
   return (
@@ -110,7 +125,12 @@ const ViewShoppingListModal = ({ show, onHide, shoppingList }: ViewShoppingListM
                     {items.map((item) => (
                       <tr key={item.id}>
                         <td>
-                          <input type="checkbox" aria-label={`Select ${item.name}`} />
+                          <input
+                            type="checkbox"
+                            checked={!!checkedState[item.id]}
+                            onChange={() => toggleCheckbox(item.id)}
+                            aria-label={`Select ${item.name}`}
+                          />
                         </td>
                         <td>{item.name}</td>
                         <td>{item.quantity}</td>


### PR DESCRIPTION
This pull request enhances the `ViewShoppingListModal` component by introducing a feature that allows users to mark individual shopping list items as checked using checkboxes. The checked state is persisted in local storage, ensuring that selections remain consistent across sessions. Additionally, a visual icon is added to the table header for clarity.

**Shopping list item selection feature:**

* Added a checkbox for each shopping list item in the table, allowing users to mark items as checked. The checked state for each item is managed in the new `checkedState` state variable.
* Persisted checkbox states in local storage using the shopping list ID as a key, so that checked items remain checked when the modal is reopened or the page is refreshed. [[1]](diffhunk://#diff-968dcf907074908a935a30a90891e05e49f2ed4309c9f00f0a04f85df5a34757R38-R45) [[2]](diffhunk://#diff-968dcf907074908a935a30a90891e05e49f2ed4309c9f00f0a04f85df5a34757R85-R96)

**UI improvements:**

* Added a `BagCheckFill` icon to the table header to visually indicate the checkbox column. [[1]](diffhunk://#diff-968dcf907074908a935a30a90891e05e49f2ed4309c9f00f0a04f85df5a34757R9) [[2]](diffhunk://#diff-968dcf907074908a935a30a90891e05e49f2ed4309c9f00f0a04f85df5a34757L94-R115)
* Updated the table to be center-aligned for improved readability.