### PR TITLE
Issue 368 - Remove unused 'fluid' prop from image in RecipeCard

### DIFF
--- a/src/components/recipes/RecipeCard.tsx
+++ b/src/components/recipes/RecipeCard.tsx
@@ -109,7 +109,6 @@ export default function RecipeCard({
             src={imageUrl || 'https://placehold.co/800x450?text=Recipe'}
             alt={title}
             className="w-100 recipe-card-img"
-            fluid
           />
         </div>
 


### PR DESCRIPTION
The 'fluid' prop was removed from the image element in RecipeCard as it is not required for the current implementation.