### PR TITLE
Issue 379 - Recipe pages styling

### DIFF
--- a/src/components/recipes/AddToShoppingList.tsx
+++ b/src/components/recipes/AddToShoppingList.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback } from 'react';
 import { Button, Spinner } from 'react-bootstrap';
+import '../../styles/buttons.css';
 
 export type MissingItem = {
   name: string;
@@ -152,7 +153,7 @@ export default function AddToShoppingList({ missingItems }: Props) {
             <div key={key} className="d-flex align-items-center gap-2">
               <Button
                 size="sm"
-                variant={added[key] ? 'success' : 'outline-primary'}
+                variant={added[key] ? 'success' : ' dish-btn-secondary'}
                 onClick={() => addOne(item)}
                 disabled={adding[key] || !!added[key]}
                 title={

--- a/src/components/recipes/UploadDishButton.tsx
+++ b/src/components/recipes/UploadDishButton.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Button } from 'react-bootstrap';
 import { CameraFill } from 'react-bootstrap-icons';
 import DishImageUploadModal from './DishImageUploadModal';
+import '../../styles/buttons.css';
 
 type Props = {
   recipeId: number;
@@ -17,9 +18,8 @@ export default function UploadDishButton({ recipeId, recipeTitle, userEmail }: P
   return (
     <>
       <Button
-        variant="primary"
         size="lg"
-        className="w-100 d-flex align-items-center justify-content-center gap-2"
+        className="w-100 d-flex align-items-center justify-content-center gap-2 dish-btn-primary"
         style={{
           fontWeight: 600,
           padding: '0.75rem 1.5rem',

--- a/src/components/recipes/ViewDishImagesButton.tsx
+++ b/src/components/recipes/ViewDishImagesButton.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Button } from 'react-bootstrap';
 import { Images } from 'react-bootstrap-icons';
 import DishImagesModal from './DishImagesModal';
+import '../../styles/buttons.css';
 
 type Props = {
   recipeId: number;
@@ -16,9 +17,8 @@ export default function ViewDishImagesButton({ recipeId, recipeTitle }: Props) {
   return (
     <>
       <Button
-        variant="outline-primary"
         size="lg"
-        className="w-100 d-flex align-items-center justify-content-center gap-2"
+        className="w-100 d-flex align-items-center justify-content-center gap-2 dish-btn-secondary"
         style={{
           fontWeight: 600,
           padding: '0.75rem 1.5rem',

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -147,3 +147,30 @@
 .location-tab:hover .delete-btn {
   opacity: 1; /* show on hover */
 }
+
+.dish-btn-primary {
+  background-color: #198754;
+  border: #198754;
+  color: white;
+}
+
+.dish-btn-primary:hover {
+  background-color: var(--fern-green);
+}
+
+.dish-btn-secondary {
+  background-color: transparent;
+  color: #d4af37;
+  border: #d4af37 solid 1px;
+}
+
+.dish-btn-secondary:hover {
+  background-color: #d4af37;
+  border: #d4af37 solid 1px;
+  color: white;
+}
+
+.dish-btn-added {
+  background-color: #d4af37 !important;
+  color: white !important;
+}

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -169,8 +169,3 @@
   border: #d4af37 solid 1px;
   color: white;
 }
-
-.dish-btn-added {
-  background-color: #d4af37 !important;
-  color: white !important;
-}


### PR DESCRIPTION
This pull request introduces custom button styles for dish-related actions and updates the relevant components to use these new styles, improving UI consistency and visual distinction for primary and secondary actions.

**UI Styling Improvements:**

* Added new CSS classes `.dish-btn-primary` and `.dish-btn-secondary` in `buttons.css` to define custom colors and hover effects for primary (green) and secondary (gold) dish-related buttons.

**Component Updates:**

* Updated `UploadDishButton` to use the `dish-btn-primary` class for its main action button, replacing the default Bootstrap variant and ensuring the new style is applied.
* Updated `ViewDishImagesButton` and the "Add to Shopping List" button in `AddToShoppingList` to use `dish-btn-secondary` for a consistent secondary action style, replacing the default Bootstrap variant. [[1]](diffhunk://#diff-a068e157902af0fe50180c1f134100a99ccab42c2f4558b41282d80d397c1e2aL19-R21) [[2]](diffhunk://#diff-51e0a87a920278f50e77f8e7319c3082a72035cfae0d762994dfa0ffe4d4383dL155-R156)
* Imported the new `buttons.css` stylesheet into `UploadDishButton.tsx`, `ViewDishImagesButton.tsx`, and `AddToShoppingList.tsx` to ensure the custom styles are available in these components. [[1]](diffhunk://#diff-d3ab523283f638c869d94c8ab5640a7d7780d8b21d6cd5f48375b9bebed50ca2R7) [[2]](diffhunk://#diff-a068e157902af0fe50180c1f134100a99ccab42c2f4558b41282d80d397c1e2aR7) [[3]](diffhunk://#diff-51e0a87a920278f50e77f8e7319c3082a72035cfae0d762994dfa0ffe4d4383dR5)